### PR TITLE
Changed|Fixed: Bump `org.lsposed.hiddenapibypass:hiddenapibypass` to …

### DIFF
--- a/termux-shared/build.gradle
+++ b/termux-shared/build.gradle
@@ -14,7 +14,7 @@ android {
         implementation "io.noties.markwon:ext-strikethrough:$markwonVersion"
         implementation "io.noties.markwon:linkify:$markwonVersion"
         implementation "io.noties.markwon:recycler:$markwonVersion"
-        implementation "org.lsposed.hiddenapibypass:hiddenapibypass:2.0"
+        implementation "org.lsposed.hiddenapibypass:hiddenapibypass:5.0"
 
         // Do not increment version higher than 1.0.0-alpha09 since it will break ViewUtils and needs to be looked into
         // noinspection GradleDependency


### PR DESCRIPTION
…`5.0` to fix crash on Android 16

```
Build fingerprint: 'google/sdk_gphone64_x86_64/emu64xa:Baklava/BP22.250103.008/12932282:userdebug/dev-keys'
Revision: '0'
ABI: 'x86_64'
Timestamp: 2025-01-25
Process uptime: 1s
Cmdline: com.termux
pid: 4700, tid: 4700, name: com.termux  >>> com.termux <<<
uid: 10212
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x000000000000000c
Cause: null pointer dereference
    rax 0000000000000000  rbx 000071ad67c247b0  rcx 000000000000000c  rdx 000071abc520c888
    r8  00005f2000006018  r9  0000607c00006004  r10 000071abc423d68c  r11 000071abc4cca7c0
    r12 00007ffc65da8240  r13 000071ad67c24858  r14 00007ffc65da85d8  r15 000071ad67c247b0
    rdi 000071ad87c26110  rsi 00007ffc65da8148
    rbp 00007ffc65da8050  rsp 00007ffc65da8040  rip 000071abc4cca817
124 total frames
backtrace:
      #00 pc 00000000008ca817  /apex/com.android.art/lib64/libart.so (art::Unsafe_getObject(_JNIEnv*, _jobject*, _jobject*, long) (.__uniq.306581074569039686346581217366878976736)+87) (BuildId: 99c067c739342eb9769974bbb229d3b3)
      #01 pc 000000000022c80b  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+219) (BuildId: 99c067c739342eb9769974bbb229d3b3)
      #02 pc 0000000000211dd4  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+756) (BuildId: 99c067c739342eb9769974bbb229d3b3)
      #03 pc 0000000000556155  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+181) (BuildId: 99c067c739342eb9769974bbb229d3b3)
      #04 pc 00000000006dd182  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, bool, art::JValue*)+2434) (BuildId: 99c067c739342eb9769974bbb229d3b3)
      #05 pc 0000000000233564  /apex/com.android.art/lib64/libart.so (void art::interpreter::ExecuteSwitchImplCpp<false>(art::interpreter::SwitchImplContext*)+10804) (BuildId: 99c067c739342eb9769974bbb229d3b3)
      #06 pc 000000000022eb25  /apex/com.android.art/lib64/libart.so (ExecuteSwitchImplAsm+5) (BuildId: 99c067c739342eb9769974bbb229d3b3)
      #07 pc 0000000000080eb4  <anonymous:71ab3d335000> (org.lsposed.hiddenapibypass.HiddenApiBypass.getDeclaredMethods+0)
      ...
      #13 pc 0000000000080dd0  <anonymous:71ab3d335000> (org.lsposed.hiddenapibypass.HiddenApiBypass.setHiddenApiExemptions+0)
      ...
      #19 pc 0000000000080cf8  <anonymous:71ab3d335000> (org.lsposed.hiddenapibypass.HiddenApiBypass.addHiddenApiExemptions+0)
      ...
      #25 pc 0000000000005ab4  <anonymous:71ae82992000> (com.termux.shared.reflection.ReflectionUtils.bypassHiddenAPIReflectionRestrictions+0)
      ...
      #31 pc 0000000000004738  <anonymous:71ae86607000> (com.termux.shared.android.SELinuxUtils.getContext+0)
      ...
      #37 pc 0000000000005b48  <anonymous:71ae825d8000> (com.termux.shared.termux.shell.command.environment.TermuxAppShellEnvironment.setTermuxAppEnvironment+0)
      ...
      #43 pc 000000000000603c  <anonymous:71ae825d8000> (com.termux.shared.termux.shell.command.environment.TermuxShellEnvironment.init+0)
      ...
      #49 pc 0000000000006a68  <anonymous:71ae7e1c2000> (com.termux.app.TermuxApplication.onCreate+0)
```

Related commit https://github.com/LSPosed/AndroidHiddenApiBypass/commit/40b4cafa478ab464c55b28c16cc12802a3bb2c59 Related issue https://github.com/LSPosed/AndroidHiddenApiBypass/issues/52

Closes #4368